### PR TITLE
Produce response for OCLC Connexion EDGCONX-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ You an also hack you way with netcat:
     java -jar ../edge-common/target/edge-common-api-key-utils.jar -g -t diku -u diku_admin >key
     echo -n "A`wc -c <key`" >req
     cat key src/test/resources/manden.marc >>req
-    nc -q1 localhost 8081 <req
+    printf '\0' >>req
+    nc localhost 8081 <req
 
 ## Additional information
 


### PR DESCRIPTION
If OCLC Client sends a nul-byte, edge-connecion makes a response
"Error: <message>\n\0" or "Import ok\n\0". If OCLC client closes
the connection, the response is lost (because the client has
closed the connection already).

The testing client for edge-conneion is now also sending nul-byte
so that it can print the reponse. The other testing scenario (with
netcat) is also updated.