### PR TITLE
Various upgrades EDGCONX-14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -55,19 +55,19 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
-      <version>4.8.0</version>
+      <version>4.10.0</version>
     </dependency>
 
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade to edge-common 4.2.1 which depends on log4j 2.16.0.
Upgrade to Vert.x 4.2.2 (also what edge-common uses).
Upgrade to junit 4.13.2.
Upgrade to okapi-common 4.10.0.