### PR TITLE
Update for login-with-expiry EDGCONX-29

### DIFF
--- a/src/main/java/org/folio/edge/connexion/EdgeClient.java
+++ b/src/main/java/org/folio/edge/connexion/EdgeClient.java
@@ -1,5 +1,7 @@
 package org.folio.edge.connexion;
 
+import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
+import io.netty.handler.codec.http.cookie.Cookie;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
@@ -22,6 +24,7 @@ public class EdgeClient {
   private final String tenant;
   private final String username;
   private final Supplier<Future<String>> getPasswordSupplier;
+  private final boolean expiry;
 
   EdgeClient(String okapiUrl, WebClient client, TokenCache cache, String tenant,
              String clientId, String username, Supplier<Future<String>> getPasswordSupplier) {
@@ -32,38 +35,63 @@ public class EdgeClient {
     this.tenant = tenant;
     this.username = username;
     this.getPasswordSupplier = getPasswordSupplier;
-  }
-
-  WebClient getClient() {
-    return client;
+    this.expiry = false; // true of using "with-expiry"
   }
 
   Future<HttpRequest<Buffer>> getToken(HttpRequest<Buffer> request) {
-    String token;
+    String cacheValue;
     try {
-      token = cache.get(clientId, tenant, username);
+      // for this to work the TTL of the TokenCache must be less than that of
+      // access token from mod-authtoken -Dtoken_cache_ttl_ms=x where
+      // x is less than 600000 (10 minutes).
+      // cache.put not saving unless expired.
+      cacheValue = cache.get(clientId, tenant, username);
     } catch (Exception e) {
       log.warn("Failed to access TokenCache {}", e.getMessage(), e);
       return Future.failedFuture("Failed to access TokenCache");
     }
-    if (token != null) {
-      request.putHeader(XOkapiHeaders.TOKEN, token);
+    if (cacheValue != null) {
+      if (!expiry) {
+        request.putHeader(XOkapiHeaders.TOKEN, cacheValue);
+        return Future.succeededFuture(request);
+      }
+      JsonObject cacheObj = new JsonObject(cacheValue);
+      // TODO use COOKIE_ACCESS_TOKEN from Okapi (not released yet)
+      Cookie cookie = ClientCookieDecoder.STRICT.decode(cacheObj.getString("folioAccessToken"));
+      request.putHeader(XOkapiHeaders.TOKEN, cookie.value());
       return Future.succeededFuture(request);
     }
+    final String loginPath = expiry ? "/authn/login-with-expiry" : "/authn/login";
     return getPasswordSupplier.get().compose(password -> {
-      JsonObject payload = new JsonObject();
-      payload.put("username", username);
-      payload.put("password", password);
-      return client.postAbs(okapiUrl + "/authn/login")
+      JsonObject payload = new JsonObject()
+          .put("username", username)
+          .put("password", password);
+      return client.postAbs(okapiUrl + loginPath)
           .expect(ResponsePredicate.SC_CREATED)
           .putHeader("Accept", "*/*") // to be safe
           .putHeader(XOkapiHeaders.TENANT, tenant)
           .sendJsonObject(payload); // also sets Content-Type to application/json
-    }).compose(res -> {
-      String newToken = res.getHeader(XOkapiHeaders.TOKEN);
-      cache.put(clientId, tenant, username, newToken);
-      request.putHeader(XOkapiHeaders.TOKEN, newToken);
-      return Future.succeededFuture(request);
+    }).map(res -> {
+      if (!expiry) {
+        String newToken = res.getHeader(XOkapiHeaders.TOKEN);
+        cache.put(clientId, tenant, username, newToken);
+        request.putHeader(XOkapiHeaders.TOKEN, newToken);
+        return request;
+      }
+      JsonObject cacheObj = res.bodyAsJsonObject();
+      res.headers().forEach(n -> {
+        if ("Set-Cookie".equals(n.getKey())) {
+          Cookie cookie = ClientCookieDecoder.STRICT.decode(n.getValue());
+          // TODO use COOKIE_ACCESS_TOKEN from Okapi (not released yet)
+          if ("folioAccessToken".equals(cookie.name())) {
+            cacheObj.put(cookie.name(), n.getValue());
+            request.putHeader(XOkapiHeaders.TOKEN, cookie.value());
+          }
+        }
+      });
+      // Not really 'put' if not-expired!
+      cache.put(clientId, tenant, username, cacheObj.encode());
+      return request;
     });
   }
 }

--- a/src/main/java/org/folio/edge/connexion/MainVerticle.java
+++ b/src/main/java/org/folio/edge/connexion/MainVerticle.java
@@ -8,7 +8,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.NetSocket;
-import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
@@ -225,15 +224,17 @@ public class MainVerticle extends EdgeVerticleCore {
         new JsonObject().put("marc",
             Base64.getEncoder().encodeToString(record.getBytes())
         ));
-    HttpRequest<Buffer> bufferHttpRequest = edgeClient.getClient()
-        .postAbs(okapiUrl + "/copycat/imports").expect(ResponsePredicate.SC_OK);
     // Accept is not necessary with mod-copycat because it's based on RMB 32.2+ RMB-519
     // Content-Type is set to application/json by sendJsonObject
-    return edgeClient.getToken(bufferHttpRequest)
+    return edgeClient.getToken(webClient
+            .postAbs(okapiUrl + "/copycat/imports")
+            .expect(ResponsePredicate.SC_OK)
+        )
         .compose(request -> request.sendJsonObject(content))
         .compose(response -> {
           log.info("Record imported via copycat");
           return Future.succeededFuture();
         });
   }
+
 }

--- a/src/main/java/org/folio/edge/connexion/TokenCache.java
+++ b/src/main/java/org/folio/edge/connexion/TokenCache.java
@@ -1,0 +1,14 @@
+package org.folio.edge.connexion;
+
+import org.folio.edge.connexion.impl.TokenCacheImpl;
+
+public interface TokenCache {
+  static TokenCache create(int capacity) {
+    return new TokenCacheImpl(capacity);
+  }
+
+  void put(String tenant, String user, String value, long expires);
+
+  String get(String tenant, String user);
+
+}

--- a/src/main/java/org/folio/edge/connexion/impl/TokenCacheImpl.java
+++ b/src/main/java/org/folio/edge/connexion/impl/TokenCacheImpl.java
@@ -31,7 +31,7 @@ public class TokenCacheImpl implements TokenCache {
   @Override
   public String get(String tenant, String user) {
     CacheValue c = entries.get(key(tenant, user));
-    return c != null ? c.value : null;
+    return c == null || c.expired() ? null : c.value;
   }
 
   @Override

--- a/src/main/java/org/folio/edge/connexion/impl/TokenCacheImpl.java
+++ b/src/main/java/org/folio/edge/connexion/impl/TokenCacheImpl.java
@@ -1,0 +1,51 @@
+package org.folio.edge.connexion.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.folio.edge.connexion.TokenCache;
+
+public class TokenCacheImpl implements TokenCache {
+
+  static class CacheValue {
+    String value;
+    long expires;
+
+    boolean expired() {
+      return expires < System.currentTimeMillis();
+    }
+  }
+
+  Map<String,CacheValue> entries = new LinkedHashMap<>();
+
+  final int capacity;
+
+  public TokenCacheImpl(int capacity) {
+    this.capacity = capacity;
+  }
+
+  private static String key(String tenant, String user) {
+    return tenant + ":" + user;
+  }
+
+  @Override
+  public String get(String tenant, String user) {
+    CacheValue c = entries.get(key(tenant, user));
+    return c != null ? c.value : null;
+  }
+
+  @Override
+  public void put(String tenant, String user, String value, long expires) {
+    CacheValue c = new CacheValue();
+    c.value = value;
+    c.expires = expires;
+    entries.put(key(tenant, user), c);
+    prune();
+  }
+
+  private void prune() {
+    entries.entrySet().removeIf(e -> e.getValue().expired());
+    AtomicInteger d = new AtomicInteger(entries.size() - capacity);
+    entries.entrySet().removeIf(e -> d.getAndDecrement() > 0);
+  }
+}

--- a/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
@@ -49,6 +49,7 @@ public class MainVerticleTest {
     vertx = Vertx.vertx();
     Router router = Router.router(vertx);
     router.route().handler(BodyHandler.create());
+    // TODO /authn/login-with-expiry
     router.post("/authn/login").handler(ctx -> {
       HttpServerRequest request = ctx.request();
       if (!"application/json".equals(request.getHeader("Content-Type"))) {
@@ -388,7 +389,7 @@ public class MainVerticleTest {
 
   @Test
   public void testEdgeClientTokenCacheFailure(TestContext context) {
-    EdgeClient edgeClient = new EdgeClient(null, null, null, "tenant", "0", "user", null);
+    EdgeClient edgeClient = new EdgeClient(null, null, null, "tenant", "user", null);
     edgeClient.getToken(null).onComplete(context.asyncAssertFailure(x ->
         context.assertEquals("Failed to access TokenCache", x.getMessage())
       ));

--- a/src/test/java/org/folio/edge/connexion/TokenCacheTest.java
+++ b/src/test/java/org/folio/edge/connexion/TokenCacheTest.java
@@ -16,13 +16,21 @@ public class TokenCacheTest {
   }
 
   @Test
-  public void testExpiry() {
+  public void testExpiryPut() {
     TokenCache tk = TokenCache.create(1);
-    Assert.assertNull(tk.get("tenant", "user1"));
     tk.put("tenant", "user1", "v1", System.currentTimeMillis() + 10000);
     Assert.assertEquals("v1", tk.get("tenant", "user1"));
     tk.put("tenant", "user2", "v2", System.currentTimeMillis() - 1);
     Assert.assertEquals("v1", tk.get("tenant", "user1"));
     Assert.assertNull(null, tk.get("tenant", "user2"));
   }
+
+  @Test
+  public void testExpiryGet() throws InterruptedException {
+    TokenCache tk = TokenCache.create(1);
+    tk.put("tenant", "user1", "v1", System.currentTimeMillis());
+    Thread.sleep(2);
+    Assert.assertNull(tk.get("tenant", "user1"));
+  }
+
 }

--- a/src/test/java/org/folio/edge/connexion/TokenCacheTest.java
+++ b/src/test/java/org/folio/edge/connexion/TokenCacheTest.java
@@ -1,0 +1,28 @@
+package org.folio.edge.connexion;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TokenCacheTest {
+  @Test
+  public void testCapacity() {
+    TokenCache tk = TokenCache.create(1);
+    Assert.assertNull(tk.get("tenant", "user1"));
+    tk.put("tenant", "user1", "v1", System.currentTimeMillis() + 10000);
+    Assert.assertEquals("v1", tk.get("tenant", "user1"));
+    tk.put("tenant", "user2", "v2", System.currentTimeMillis() + 10000);
+    Assert.assertEquals("v2", tk.get("tenant", "user2"));
+    Assert.assertNull(null, tk.get("tenant", "user1"));
+  }
+
+  @Test
+  public void testExpiry() {
+    TokenCache tk = TokenCache.create(1);
+    Assert.assertNull(tk.get("tenant", "user1"));
+    tk.put("tenant", "user1", "v1", System.currentTimeMillis() + 10000);
+    Assert.assertEquals("v1", tk.get("tenant", "user1"));
+    tk.put("tenant", "user2", "v2", System.currentTimeMillis() - 1);
+    Assert.assertEquals("v1", tk.get("tenant", "user1"));
+    Assert.assertNull(null, tk.get("tenant", "user2"));
+  }
+}


### PR DESCRIPTION
For this to work the, TTL of the TokenCache must be less than that of access token from mod-authtoken -Dtoken_cache_ttl_ms=x where x is less than 600000 (10 minutes).

edge-common probably should be changed, so that the token we get dictates expiry (not a setting in edge-common).