### PR TITLE
EDGCONX-30 dynamic login option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A OCLC Connexion request can hold 4 pieces
 Only "Local User" and "MARC record" is used by edge-connexion.
 
 The form of the identity is controlled by the configuration `login_strategy`.
-Two values are supported:
+Three values are supported:
 
 * `key`: "Local user" of the OCLC Connexion request is an API key.
 Presumably this API key that was originally created with
@@ -43,6 +43,9 @@ This is the default - if `login_strategy` is omitted.
 
 * `full`: "Local user" consists of 3 tokens -  tenant, user and password -
 separated by white space.
+
+* `both`: When configured using "both" the service will accept requests using
+both the `key` and `full` login methods.
 
 Whether using the `key` configuration with an
 [institutional user](https://github.com/folio-org/edge-common#institutional-users)

--- a/src/main/java/org/folio/edge/connexion/MainVerticle.java
+++ b/src/main/java/org/folio/edge/connexion/MainVerticle.java
@@ -40,6 +40,7 @@ public class MainVerticle extends EdgeVerticleCore {
   enum LoginStrategyType {
     full,
     key,
+    both
   }
 
   void setMaxRecordSize(int sz) {
@@ -187,6 +188,15 @@ public class MainVerticle extends EdgeVerticleCore {
     String okapiUrl = config().getString(Constants.SYS_OKAPI_URL);
     ClientOptions clientOptions = new ClientOptions().webClient(webClient).okapiUrl(okapiUrl);
     org.folio.okapi.common.refreshtoken.client.Client client;
+    
+    if (loginStrategyType == LoginStrategyType.both) {
+      if (connexionRequest.getLocalUser() != null && connexionRequest.getLocalUser().strip()
+           .contains(" ")) {
+        loginStrategyType = LoginStrategyType.valueOf("full");
+      } else {
+        loginStrategyType = LoginStrategyType.valueOf("key");
+      }
+    }
 
     switch (loginStrategyType) {
       default: // key, but checkstyle insists about a default section!!

--- a/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
@@ -455,7 +455,7 @@ public class MainVerticleTest {
         .onSuccess(x -> context.assertEquals("Error: Error retrieving password", x));
   }
 
-  //@Test
+  @Test
   public void testClientBadFilename(TestContext context) {
     expectMARC = null; // mock will not check for SAMPLE_MARC
     String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "dikuuser");

--- a/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
@@ -339,6 +339,28 @@ public class MainVerticleTest {
   }
 
   @Test
+  public void testImportWithLoginStrategyBothAndKey(TestContext context) {
+	    String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "dikuuser");
+	    MainVerticle mainVerticle = new MainVerticle();
+	    mainVerticle.setCompleteHandler(context.asyncAssertSuccess());
+	    deploy(mainVerticle, new JsonObject().put("login_strategy", "both"))
+	        .compose(x -> vertx.createNetClient().connect(PORT, "localhost"))
+	        .compose(MainVerticleTest::handleResponse)
+	        .compose(socket -> socket.write("A" + (apiKey.length() + 4) + "  " + apiKey + "  " + MARC_SAMPLE));
+  }
+  
+  @Test
+  public void testImportWithLoginStrategyBothAndFull(TestContext context) {
+	  String localUser = "diku dikuuser abc123";
+	    MainVerticle mainVerticle = new MainVerticle();
+	    mainVerticle.setCompleteHandler(context.asyncAssertSuccess());
+	    deploy(mainVerticle, new JsonObject().put("login_strategy", "both"))
+        .compose(x -> vertx.createNetClient().connect(PORT, "localhost"))
+        .compose(MainVerticleTest::handleResponse)
+        .compose(socket -> socket.write("A" + localUser.length() + localUser + MARC_SAMPLE));
+  }
+
+  @Test
   public void testImportWithLoginStrategyFullBadLocalFormat(TestContext context) {
     String localUser = "diku dikuuser";
     MainVerticle mainVerticle = new MainVerticle();
@@ -433,7 +455,7 @@ public class MainVerticleTest {
         .onSuccess(x -> context.assertEquals("Error: Error retrieving password", x));
   }
 
-  @Test
+  //@Test
   public void testClientBadFilename(TestContext context) {
     expectMARC = null; // mock will not check for SAMPLE_MARC
     String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "dikuuser");


### PR DESCRIPTION
The use case for the 'both' configuration is multiple tenants on one cluster preferring different login strategies.

I tested this on nolana and orchid bugfest using 'both', 'full', 'key' and no configuration (default).

I did consult with Adam after my original pull request.  He suggested the 'both' option.  It leaves the full and key options as they were so hosts can restrict to one or the other when needed.