### PR TITLE
EDGCONX-37: Vert.x 4.4.6, log4j 2.20.0, jackson 2.15.0, Netty 4.1.100

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.20.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.8</version>
+        <version>4.4.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.8 to the Poppy version 4.4.6.

Upgrade log4j from 2.17.* to 2.20.0 to use a version that is compatible with Vert.x.

Upgrading Vert.x indirectly upgrades jackson-core from 2.14.0 to 2.15.0 fixing Number Parse DoS (RISMA-2023-0067): https://github.com/FasterXML/jackson-core/pull/827

Upgrading Vert.x indirectly upgrades Netty from 4.1.87.Final to 4.1.100.Final fixing HTTP/2 DoS: https://nvd.nist.gov/vuln/detail/CVE-2023-44487