### PR TITLE
EDGCONX-52 Upgrade AWS SDK from 1.x to 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.7.1</version>
+      <version>4.9.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio.okapi</groupId>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
+      <version>3.17.0</version>
     </dependency>
   <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,7 @@
       <artifactId>okapi-common</artifactId>
       <version>5.0.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
-    </dependency>
-  <!-- Test dependencies -->
+    <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.9.0-SNAPSHOT</version>
+      <version>4.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.folio.okapi</groupId>

--- a/src/main/java/org/folio/edge/connexion/MainVerticle.java
+++ b/src/main/java/org/folio/edge/connexion/MainVerticle.java
@@ -5,7 +5,6 @@ import static org.folio.edge.core.Constants.FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD;
 import static org.folio.edge.core.Constants.FOLIO_CLIENT_TLS_TRUSTSTOREPATH;
 import static org.folio.edge.core.Constants.FOLIO_CLIENT_TLS_TRUSTSTORETYPE;
 
-import com.amazonaws.util.StringUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -22,6 +21,7 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.Constants;
@@ -266,9 +266,9 @@ public class MainVerticle extends EdgeVerticleCore {
       String truststoreType = config().getString(FOLIO_CLIENT_TLS_TRUSTSTORETYPE);
       String truststorePath = config().getString(FOLIO_CLIENT_TLS_TRUSTSTOREPATH);
       String truststorePassword = config().getString(FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD);
-      if (!StringUtils.isNullOrEmpty(truststoreType)
-          && !StringUtils.isNullOrEmpty(truststorePath)
-          && !StringUtils.isNullOrEmpty(truststorePassword)) {
+      if (StringUtils.isNotEmpty(truststoreType)
+          && StringUtils.isNotEmpty(truststorePath)
+          && StringUtils.isNotEmpty(truststorePassword)) {
 
         log.info("Web client truststore options for type: {} are set, "
             + "configuring Web Client with them", truststoreType);


### PR DESCRIPTION
  OBS: by depending on new snapshot version 4.9.0 of edge-common
  - update commons-lang3 to 3.17.0
  - use commons.lang3.StringUtils instead of aws StringUtils and adapt a line of code