### PR TITLE
EDGCONX-54 Use OKAPI 6.2.2, Vert.x 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.3</version>
+        <version>4.5.13</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
-      <version>5.0.0</version>
+      <version>6.2.2</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/org/folio/edge/connexion/MainVerticle.java
+++ b/src/main/java/org/folio/edge/connexion/MainVerticle.java
@@ -18,7 +18,6 @@ import io.vertx.core.net.TrustOptions;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
@@ -30,6 +29,7 @@ import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.utils.ApiKeyUtils;
 import org.folio.edge.core.utils.SslConfigurationUtil;
+import org.folio.okapi.common.ChattyHttpResponseExpectation;
 import org.folio.okapi.common.refreshtoken.client.Client;
 import org.folio.okapi.common.refreshtoken.client.ClientOptions;
 import org.folio.okapi.common.refreshtoken.tokencache.TenantUserCache;
@@ -246,12 +246,13 @@ public class MainVerticle extends EdgeVerticleCore {
             Base64.getEncoder().encodeToString(record.getBytes())
         ));
     HttpRequest<Buffer> bufferHttpRequest = webClient
-        .postAbs(okapiUrl + "/copycat/imports").expect(ResponsePredicate.SC_OK);
+        .postAbs(okapiUrl + "/copycat/imports");
 
     // Accept is not necessary with mod-copycat because it's based on RMB 32.2+ RMB-519
     // Content-Type is set to application/json by sendJsonObject
     return client.getToken(bufferHttpRequest)
         .compose(request -> request.sendJsonObject(content))
+        .expecting(ChattyHttpResponseExpectation.SC_OK)
         .compose(response -> {
           log.info("Record imported via copycat");
           return Future.succeededFuture();

--- a/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/connexion/MainVerticleTest.java
@@ -12,11 +12,11 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.ApiKeyUtils;
+import org.folio.okapi.common.ChattyHttpResponseExpectation;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.junit.After;
 import org.junit.Assert;
@@ -57,7 +57,7 @@ public class MainVerticleTest {
         ctx.response().end("Bad Request");
         return;
       }
-      JsonObject login = ctx.getBodyAsJson();
+      JsonObject login = ctx.body().asJsonObject();
       String username = login.getString("username");
       String password = login.getString("password");
       // only accept the diku that is in src/test/resources/ephemeral.properties
@@ -171,8 +171,8 @@ public class MainVerticleTest {
     WebClient webClient = WebClient.create(vertx);
     deploy(new MainVerticle())
         .compose(x -> webClient.get(PORT, "localhost", "/admin/health")
-            .expect(ResponsePredicate.SC_OK)
-            .send())
+            .send()
+            .expecting(ChattyHttpResponseExpectation.SC_OK))
         .onComplete(context.asyncAssertSuccess());
   }
 
@@ -181,11 +181,11 @@ public class MainVerticleTest {
     WebClient webClient = WebClient.create(vertx);
     deploy(new MainVerticle())
         .compose(x -> webClient.get(PORT, "localhost", "/admin/health")
-            .expect(ResponsePredicate.SC_OK)
-            .send())
+            .send()
+            .expecting(ChattyHttpResponseExpectation.SC_OK))
         .compose(x -> webClient.get(PORT, "localhost", "/other")
-            .expect(ResponsePredicate.SC_OK)
-            .send())
+            .send()
+            .expecting(ChattyHttpResponseExpectation.SC_OK))
         .onComplete(context.asyncAssertSuccess());
   }
 
@@ -363,7 +363,7 @@ public class MainVerticleTest {
     String localUser = "diku dikuuser abc123";
     MainVerticle mainVerticle = new MainVerticle();
     mainVerticle.setCompleteHandler(context.asyncAssertFailure(x ->
-        context.assertEquals("Response status code 400 is not equal to 200", x.getMessage())));
+        context.assertEquals("Response status code 400 is not equal to 200: Bad request (bad MARC)", x.getMessage())));
     deploy(mainVerticle, new JsonObject().put("login_strategy", "full"))
         .compose(x -> vertx.createNetClient().connect(PORT, "localhost"))
         .compose(MainVerticleTest::handleResponse)


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCONX-54

[okapi-common 6.2.2](https://github.com/folio-org/okapi/releases/tag/v6.2.2) includes [OKAPI-1208](https://folio-org.atlassian.net/browse/OKAPI-1208) fix which ensures that X-Okapi-Tenant is sent along with X-Okapi-Token. This should fix working in Eureka environment where sidecar requires X-Okapi-Tenant to be set.